### PR TITLE
security: remove NPM token from history

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,40 @@
 FROM node:14.8.0 as build
 ARG NPM_TOKEN
 WORKDIR /home/node/app
-COPY package.json package-lock.json ./
-RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-RUN npm ci
-# COPY ./graphql-codegen-joist.js ./
+COPY package.json package-lock.json .npmrc ./
+RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc && \
+  npm ci && \
+  npm cache clean --force && \
+  rm -fr .npmrc
+COPY ./graphql-codegen-joist.js ./
 COPY ./graphql-codegen.js ./
 COPY ./tsconfig.json ./
-#COPY ./.eslintrc.js ./
-#COPY ./.eslintignore ./
 COPY ./migrations ./migrations
 COPY ./schema ./schema
 COPY ./src ./src
 RUN npm run graphql-codegen
 RUN npm run build
 
-# Now start over with out dev dependencies
+# Install production dependencies in a separate stage. This isn't done in the
+# runtime stage to keep the NPM_TOKEN out of the docker image history.
+FROM node:14.8.0 as proddeps
+ARG NPM_TOKEN
+WORKDIR /home/node/app
+COPY package.json package-lock.json .npmrc ./
+RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc && \
+  npm ci --only production && \
+  npm cache clean --force && \
+  rm -fr .npmrc
+
+# build the final runtime image
 FROM node:14.8.0 as runtime
 ARG NPM_TOKEN
 WORKDIR /home/node/app
-COPY package.json package-lock.json ./
-RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-RUN npm ci --only=production
-
+COPY package.json package-lock.json .npmrc ./
 COPY tsconfig.json ./
 COPY ./schema ./schema
 COPY --from=build /home/node/app/dist/src ./src
 COPY --from=build /home/node/app/dist/migrations ./migrations
+COPY --from=proddeps /home/node/app/node_modules ./node_modules
 CMD ["node", "src/server.js"]
 EXPOSE 4000


### PR DESCRIPTION
This PR updates the `Dockerfile` to remove the NPM token.

## Background

Previously, there were two distinct issues where the `NPM_TOKEN` could be exploited by an attacker.

### Docker Image History

Previously, because the final `runtime` image put the `NPM_TOKEN` into the `.npmrc` file, it was retained in history:

```
> docker history sample-app:npm-token-before --no-trunc | grep -i npm

19 hours ago   |1 NPM_TOKEN=<REDACTED> /bin/sh -c npm ci --only=production                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        332MB
19 hours ago   |1 NPM_TOKEN=<REDACTED> /bin/sh -c echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
```

This could allow an attacker access to our private NPM repositories.

### Docker Image Contents

In addition to the image history, the `.npmrc` was present with the token in the final file:

```
> docker run -it --rm --entrypoint bash sample-app:npm-token-before

root@45927f400215:/home/node/app# cat .npmrc
//registry.npmjs.org/:_authToken=<REDACTED>
```

## The Fix

This PR leverages an additional build stage to prevent the NPM token from leaking.

The token is no longer in history:

```
> docker history sampel-app:npm-token-after --no-trunc | grep -i npm
37 minutes ago   COPY package.json package-lock.json .npmrc ./ # buildkit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     2.02MB    buildkit.dockerfile.v0
50 minutes ago   ARG NPM_TOKEN
```

And the `.npmrc` file no longer has the token:

```
> docker run -it --rm --entrypoint bash sample-app:npm-token-after
root@7c1363601505:/home/node/app# cat .npmrc
engine-strict=true
```